### PR TITLE
Fix issue #2

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -991,7 +991,7 @@ test_diff <- function(se, type = c("control", "all", "manual"),
     unite(temp, comparison, variable) %>%
     spread(temp, value)
   rowData(se) <- merge(rowData(se, use.names = FALSE), table,
-    by.x = "name", by.y = "rowname", all.x = TRUE)
+    by.x = "name", by.y = "rowname", all.x = TRUE, sort=FALSE)
   return(se)
 }
 


### PR DESCRIPTION
- Set sort=FALSE in merge call in test_diff to make sure that p-values are in the correct order.
- Previously it only returned the correct order if the rows of the SummarizedExperiment were ordered alphabetically
- Add test to confirm that behavior is correct now