### PR TITLE
fix get_annotation for exactly 7 levels

### DIFF
--- a/R/plot_functions_results.R
+++ b/R/plot_functions_results.R
@@ -229,7 +229,7 @@ get_annotation <- function(dep, indicate) {
       cols <- c("orangered", "cornflowerblue")
     if(length(var) < 7 & length(var) > 2)
       cols <- RColorBrewer::brewer.pal(length(var), "Pastel1")
-    if(length(var) > 7)
+    if(length(var) >= 7)
       cols <- RColorBrewer::brewer.pal(length(var), "Set3")
     names(cols) <- var
     anno_col[[i]] <-  cols


### PR DESCRIPTION
The `Pastel1` palette can support up to 9 colours, but I've erred on the side of caution and set it to change to `Set3` when there are 7 or more levels.

resolves #12 