### PR TITLE
Bug fix in filter_missval()

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -445,6 +445,7 @@ filter_missval <- function(se, thr = 0) {
     summarize(miss_val = n() - sum(value)) %>%
     filter(miss_val <= thr) %>%
     spread(condition, miss_val)
+  keep$rowname <- as.numeric(keep$rowname)
   se_fltrd <- se[keep$rowname, ]
   return(se_fltrd)
 }


### PR DESCRIPTION
Fixing bug in filter_missval(): 

keep$rowname is vector of character strings but should be row index, hence turned to integer.

Error in .SummarizedExperiment.charbound(i, rownames(x), fmt): <SummarizedExperiment>[i,] index out of bounds: 10 100 ... 9998 9999 Traceback:

1. DEP::filter_missval(data_se, thr = 1)
2. se[keep$rowname, ]
3. se[keep$rowname, ]
4. .SummarizedExperiment.charbound(i, rownames(x), fmt)
5. stop(sprintf(fmt, msg))